### PR TITLE
Bring up a single org worker in macstadium-prod-1

### DIFF
--- a/macstadium-prod-1/env.yml
+++ b/macstadium-prod-1/env.yml
@@ -1,15 +1,15 @@
 ---
 modules:
-  #  worker-common:
-  #    module: macstadium-worker-config
-  #  worker-org:
-  #    module: macstadium-worker
-  #    env: prod-1-org
-  #    site: org
-  #    replicas: 1
-  #    #replicas: 8
-  #    pool_size: 20
-  #    jupiter_brain_name: jupiter-brain-org
+  worker-common:
+    module: macstadium-worker-config
+  worker-org:
+    module: macstadium-worker
+    env: prod-1-org
+    site: org
+    replicas: 1
+    #replicas: 8
+    pool_size: 20
+    jupiter_brain_name: jupiter-brain-org
   #  worker-com:
   #    module: macstadium-worker
   #    env: prod-1-com


### PR DESCRIPTION
This uses the same common macstadium-worker module that is powering the staging workers, but overriding to have a single replica for now.

This worker replaces the pool size decrease in https://github.com/travis-ci/terraform-config/pull/603