### PR TITLE
Add a single worker for .com in macstadium-prod-1

### DIFF
--- a/releases/macstadium-prod-1/worker-com.yaml
+++ b/releases/macstadium-prod-1/worker-com.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: worker-com
+  namespace: macstadium-prod-1
+  labels:
+    chart: macstadium-worker
+spec:
+  chartGitPath: macstadium-worker
+  releaseName: worker-com
+  values:
+    image:
+      tag: v4.6.3
+    # Eventually this should be:
+    # replicaCount: 5
+    replicaCount: 1
+    site: com
+    poolSize: 21
+    jupiterBrainName: jupiter-brain-com
+    secretEnv: production-common


### PR DESCRIPTION
Going along with https://github.com/travis-ci/terraform-config/pull/609, we want to bring up another worker and have more macstadium-prod-1 traffic going through Kubernetes. After this change, we'll have a single worker each running for .org and .com.