### PR TITLE
Add script to install Heapster for metrics

### DIFF
--- a/shared/heapster-role.yaml
+++ b/shared/heapster-role.yaml
@@ -1,0 +1,38 @@
+# The default version of this role in our cluster does not have the "nodes/stats"
+# resource available, so Heapster gets a 403 Forbidden when trying to get metrics
+# from nodes. We have to manually patch this to add that permission.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:heapster
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/stats
+  verbs:
+  - get

--- a/shared/heapster-values.yaml
+++ b/shared/heapster-values.yaml
@@ -1,0 +1,6 @@
+rbac:
+  create: true
+
+command:
+  - /heapster
+  - "--source=kubernetes.summary_api:https://kubernetes.default?kubeletHttps=true&kubeletPort=10250&insecure=true"

--- a/shared/install-metrics.sh
+++ b/shared/install-metrics.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+TOP=$(git rev-parse --show-toplevel)
+
+helm upgrade heapster stable/heapster \
+  -i \
+  --namespace kube-system \
+  --values "$TOP/shared/heapster-values.yaml"
+
+kubectl replace -f "$TOP/shared/heapster-role.yaml"


### PR DESCRIPTION
This exposes information about CPU/memory usage for nodes and pods. It can be seen currently in the Kubernetes dashboard.

I'll open another PR for setting this up to use statsd in order to get the metrics into Librato.