### PR TITLE
Pull non-secret settings into jupiter-brain configmap

### DIFF
--- a/charts/jupiter-brain/templates/configmap.yaml
+++ b/charts/jupiter-brain/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jupiter-brain.fullname" . }}
+data:
+  JUPITER_BRAIN_VSPHERE_CONCURRENT_CREATE_OPERATIONS: "{{ .Values.concurrency.create }}"
+  JUPITER_BRAIN_VSPHERE_CONCURRENT_DELETE_OPERATIONS: "{{ .Values.concurrency.delete }}"
+  JUPITER_BRAIN_REQUEST_TIMEOUT: {{ .Values.requestTimeout }}
+  JUPITER_BRAIN_HONEYCOMB_REQUEST_DATASET: {{ .Values.honeycomb.dataset }}
+  JUPITER_BRAIN_HONEYCOMB_SAMPLE_RATE: "{{ .Values.honeycomb.sampleRate }}"

--- a/charts/jupiter-brain/templates/deployment.yaml
+++ b/charts/jupiter-brain/templates/deployment.yaml
@@ -41,5 +41,7 @@ spec:
         - name: JUPITER_BRAIN_LIBRATO_SOURCE
           value: $(POD_NAMESPACE)-$(POD_NAME)
         envFrom:
+        - configMapRef:
+            name: {{ template "jupiter-brain.fullname" . }}
         - secretRef:
             name: {{ include "jupiter-brain.fullname" . }}

--- a/charts/jupiter-brain/values.yaml
+++ b/charts/jupiter-brain/values.yaml
@@ -15,6 +15,16 @@ fullnameOverride: ""
 secretEnv: ""
 pro: false
 
+concurrency:
+  create: 20
+  delete: 20
+
+requestTimeout: 5m
+
+honeycomb:
+  dataset: ""
+  sampleRate: 1
+
 service:
   type: ClusterIP
   port: 80

--- a/releases/macstadium-prod-1/jupiter-brain-com.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-com.yaml
@@ -11,3 +11,6 @@ spec:
   values:
     secretEnv: production-1
     pro: true
+    honeycomb:
+      dataset: jb-requests
+      sampleRate: 10

--- a/releases/macstadium-prod-1/jupiter-brain-org.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-org.yaml
@@ -10,3 +10,6 @@ spec:
   releaseName: jupiter-brain-org
   values:
     secretEnv: production-1
+    honeycomb:
+      dataset: jb-requests
+      sampleRate: 10

--- a/releases/macstadium-staging/jupiter-brain-com.yaml
+++ b/releases/macstadium-staging/jupiter-brain-com.yaml
@@ -11,3 +11,5 @@ spec:
   values:
     secretEnv: staging-1
     pro: true
+    honeycomb:
+      dataset: jb-requests-staging

--- a/releases/macstadium-staging/jupiter-brain-org.yaml
+++ b/releases/macstadium-staging/jupiter-brain-org.yaml
@@ -10,3 +10,5 @@ spec:
   releaseName: jupiter-brain-org
   values:
     secretEnv: staging-1
+    honeycomb:
+      dataset: jb-requests-staging


### PR DESCRIPTION
These settings don't need the complexity of going through the keychain and being defined in a secret. Defining them in the chart values and a ConfigMap makes it more obvious that they can be configured, while still letting us provide default values.

I think this is an approach we should take with our Helm charts in general: keep only what we have to in secrets, and use a ConfigMap and the values.yaml to provide all other configuration.

For the time being, that may mean a little duplication of configuration between here and the keychain, since we still have services not deployed in Kubernetes, but that's temporary.

Fixes #12.