### PR TITLE
Make TrvsSecret optional for jupiter-brain

### DIFF
--- a/charts/jupiter-brain/templates/_helpers.tpl
+++ b/charts/jupiter-brain/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "jupiter-brain.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Use the fullname as the secret name unless a secretName has been provided.
+*/}}
+{{- define "jupiter-brain.secret" -}}
+{{- if .Values.secretName -}}
+{{- .Values.secretName -}}
+{{- else -}}
+{{- include "jupiter-brain.fullname" . }}
+{{- end -}}
+{{- end -}}

--- a/charts/jupiter-brain/templates/deployment.yaml
+++ b/charts/jupiter-brain/templates/deployment.yaml
@@ -44,4 +44,4 @@ spec:
         - configMapRef:
             name: {{ template "jupiter-brain.fullname" . }}
         - secretRef:
-            name: {{ include "jupiter-brain.fullname" . }}
+            name: {{ include "jupiter-brain.secret" . }}

--- a/charts/jupiter-brain/templates/secret.yaml
+++ b/charts/jupiter-brain/templates/secret.yaml
@@ -1,14 +1,16 @@
+{{- if .Values.trvs.enabled }}
 apiVersion: travisci.com/v1
 kind: TrvsSecret
 metadata:
-  name: {{ include "jupiter-brain.fullname" . }}
+  name: {{ include "jupiter-brain.secret" . }}
   labels:
     app.kubernetes.io/name: {{ include "jupiter-brain.name" . }}
     helm.sh/chart: {{ include "jupiter-brain.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  app: jupiter-brain
-  env: {{ .Values.secretEnv }}
+  app: {{ .Values.trvs.app }}
+  env: {{ .Values.trvs.env }}
   prefix: JUPITER_BRAIN
-  pro: {{ .Values.pro }}
+  pro: {{ .Values.trvs.pro }}
+{{- end }}

--- a/charts/jupiter-brain/values.yaml
+++ b/charts/jupiter-brain/values.yaml
@@ -12,8 +12,23 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-secretEnv: ""
-pro: false
+# Pull secrets from trvs keychain
+trvs:
+  # If not enabled, be sure to set secretName and create a secret with the
+  # necessary environment variables for jupiter-brain
+  enabled: false
+  app: jupiter-brain
+  env: ""
+  pro: false
+
+# Override the name of the secret with environment variables.
+#
+# If trvs.enabled is true, it will create a secret with this name instead
+# of using the fullname of the deployment.
+#
+# If trvs.enabled is false, this should be set and you must create a secret
+# with the given name that has the right environment variables.
+secretName: ""
 
 concurrency:
   create: 20

--- a/releases/macstadium-prod-1/jupiter-brain-com.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-com.yaml
@@ -9,8 +9,10 @@ spec:
   chartGitPath: jupiter-brain
   releaseName: jupiter-brain-com
   values:
-    secretEnv: production-1
-    pro: true
+    trvs:
+      enabled: true
+      env: production-1
+      pro: true
     honeycomb:
       dataset: jb-requests
       sampleRate: 10

--- a/releases/macstadium-prod-1/jupiter-brain-org.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-org.yaml
@@ -9,7 +9,9 @@ spec:
   chartGitPath: jupiter-brain
   releaseName: jupiter-brain-org
   values:
-    secretEnv: production-1
+    trvs:
+      enabled: true
+      env: production-1
     honeycomb:
       dataset: jb-requests
       sampleRate: 10

--- a/releases/macstadium-staging/jupiter-brain-com.yaml
+++ b/releases/macstadium-staging/jupiter-brain-com.yaml
@@ -9,7 +9,9 @@ spec:
   chartGitPath: jupiter-brain
   releaseName: jupiter-brain-com
   values:
-    secretEnv: staging-1
-    pro: true
+    trvs:
+      enabled: true
+      env: staging-1
+      pro: true
     honeycomb:
       dataset: jb-requests-staging

--- a/releases/macstadium-staging/jupiter-brain-org.yaml
+++ b/releases/macstadium-staging/jupiter-brain-org.yaml
@@ -9,6 +9,8 @@ spec:
   chartGitPath: jupiter-brain
   releaseName: jupiter-brain-org
   values:
-    secretEnv: staging-1
+    trvs:
+      enabled: true
+      env: staging-1
     honeycomb:
       dataset: jb-requests-staging


### PR DESCRIPTION
Part of #14, for jupiter-brain only so far.

The idea is that you control whether a `TrvsSecret` resource is created with the `trvs.enabled` value for the chart. For situations where we don't want to use `trvs` for secret management, like enterprise, a new `secretName` value can specify the name of an independently-created Kubernetes secret to use for secret environment variables.