### PR TITLE
Add infra for limiting concurrent worker jobs in MacStadium

### DIFF
--- a/charts/macstadium-worker/templates/concurrency-configmap.yaml
+++ b/charts/macstadium-worker/templates/concurrency-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "macstadium-worker.fullname" . }}-concurrency
+data:
+  total-concurrent-jobs: "{{ .Values.concurrency.totalJobs }}"

--- a/charts/macstadium-worker/templates/configmap.yaml
+++ b/charts/macstadium-worker/templates/configmap.yaml
@@ -29,6 +29,6 @@ data:
 
   {{- if .Values.concurrency.redis.name -}}
   TRAVIS_WORKER_CONCURRENT_JOBS_REDIS_URL: "redis://{{ .Values.concurrency.redis.name }}/"
-  TRAVIS_WORKER_CONCURRENT_JOBS_PREFIX: {{ include "macstadium-worker.fullname" }}
+  TRAVIS_WORKER_CONCURRENT_JOBS_PREFIX: {{ include "macstadium-worker.fullname" . }}
   TRAVIS_WORKER_CONCURRENT_JOBS_TOTAL_FILE: /etc/worker/total-concurrent-jobs
   {{- end -}}

--- a/charts/macstadium-worker/templates/configmap.yaml
+++ b/charts/macstadium-worker/templates/configmap.yaml
@@ -27,8 +27,8 @@ data:
   TRAVIS_WORKER_STARTUP_TIMEOUT: "8m"
   TRAVIS_WORKER_SCRIPT_UPLOAD_TIMEOUT: "6m"
 
-  {{- if .Values.redis.name -}}
-  TRAVIS_WORKER_CONCURRENT_JOBS_REDIS_URL: "redis://{{ .Values.redis.name }}/"
+  {{- if .Values.concurrency.redis.name -}}
+  TRAVIS_WORKER_CONCURRENT_JOBS_REDIS_URL: "redis://{{ .Values.concurrency.redis.name }}/"
   TRAVIS_WORKER_CONCURRENT_JOBS_PREFIX: {{ include "macstadium-worker.fullname" }}
   TRAVIS_WORKER_CONCURRENT_JOBS_TOTAL_FILE: /etc/worker/total-concurrent-jobs
   {{- end -}}

--- a/charts/macstadium-worker/templates/configmap.yaml
+++ b/charts/macstadium-worker/templates/configmap.yaml
@@ -27,8 +27,8 @@ data:
   TRAVIS_WORKER_STARTUP_TIMEOUT: "8m"
   TRAVIS_WORKER_SCRIPT_UPLOAD_TIMEOUT: "6m"
 
-  {{- if .Values.concurrency.redis.name -}}
+  {{ if .Values.concurrency.redis.name -}}
   TRAVIS_WORKER_CONCURRENT_JOBS_REDIS_URL: "redis://{{ .Values.concurrency.redis.name }}/"
   TRAVIS_WORKER_CONCURRENT_JOBS_PREFIX: {{ include "macstadium-worker.fullname" . }}
   TRAVIS_WORKER_CONCURRENT_JOBS_TOTAL_FILE: /etc/worker/total-concurrent-jobs
-  {{- end -}}
+  {{- end }}

--- a/charts/macstadium-worker/templates/configmap.yaml
+++ b/charts/macstadium-worker/templates/configmap.yaml
@@ -4,20 +4,31 @@ metadata:
   name: {{ include "macstadium-worker.fullname" . }}
 data:
   TRAVIS_WORKER_TRAVIS_SITE: "{{ .Values.site }}"
-  TRAVIS_WORKER_POOL_SIZE: "{{ .Values.poolSize }}"
-  TRAVIS_WORKER_AMQP_HEARTBEAT: "60s"
+  TRAVIS_WORKER_POOL_SIZE: "{{ .Values.concurrency.poolSize }}"
+
   TRAVIS_WORKER_BUILD_FIX_ETC_HOSTS: "true"
   TRAVIS_WORKER_BUILD_FIX_RESOLV_CONF: "true"
   TRAVIS_WORKER_BUILD_PARANOID: "false"
+
   TRAVIS_WORKER_BUILD_TRACE_ENABLED: "true"
   TRAVIS_WORKER_BUILD_TRACE_S3_KEY_PREFIX: trace/
   TRAVIS_WORKER_BUILD_TRACE_S3_REGION: us-east-1
-  TRAVIS_WORKER_INFRA: "macstadium"
+
   TRAVIS_WORKER_QUEUE_TYPE: "amqp"
   TRAVIS_WORKER_QUEUE_NAME: "{{ .Values.queue }}"
+  TRAVIS_WORKER_AMQP_HEARTBEAT: "60s"
+  TRAVIS_WORKER_RABBITMQ_SHARDING: "true"
+
+  TRAVIS_WORKER_INFRA: "macstadium"
   TRAVIS_WORKER_PROVIDER_NAME: "jupiterbrain"
   TRAVIS_WORKER_JUPITERBRAIN_IMAGE_SELECTOR_TYPE: "api"
   TRAVIS_WORKER_JUPITERBRAIN_SSH_KEY_PATH: "/etc/secret/travis-vm.key"
+
   TRAVIS_WORKER_STARTUP_TIMEOUT: "8m"
   TRAVIS_WORKER_SCRIPT_UPLOAD_TIMEOUT: "6m"
-  TRAVIS_WORKER_RABBITMQ_SHARDING: "true"
+
+  {{- if .Values.redis.name -}}
+  TRAVIS_WORKER_CONCURRENT_JOBS_REDIS_URL: "redis://{{ .Values.redis.name }}/"
+  TRAVIS_WORKER_CONCURRENT_JOBS_PREFIX: {{ include "macstadium-worker.fullname" }}
+  TRAVIS_WORKER_CONCURRENT_JOBS_TOTAL_FILE: /etc/worker/total-concurrent-jobs
+  {{- end -}}

--- a/charts/macstadium-worker/templates/deployment.yaml
+++ b/charts/macstadium-worker/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
           value: $(POD_NAMESPACE)-$(POD_NAME)
         - name: TRAVIS_WORKER_HOSTNAME
           value: $(POD_NAME).$(POD_NAMESPACE)
+        - name: TRAVIS_WORKER_CONCURRENT_JOBS_NAME
+          values: $(POD_NAME)
 
         # The worker secret will have these prefixed with TRAVIS_WORKER,
         # but the AWS library wants these variable names instead.
@@ -63,10 +65,16 @@ spec:
         - name: travis-vm-ssh-key
           mountPath: "/etc/secret"
           readOnly: true
+        - name: concurrent-jobs
+          mountPath: "/etc/worker"
+          readOnly: true
       volumes:
       - name: travis-vm-ssh-key
         secret:
           secretName: {{ template "macstadium-worker.fullname" . }}-vm-key
+      - name: concurrent-jobs
+        configMap:
+          name: {{ template "macstadium-worker.fullname" . }}-concurrency
       terminationGracePeriodSeconds: 7200
   strategy:
     rollingUpdate:

--- a/charts/macstadium-worker/templates/deployment.yaml
+++ b/charts/macstadium-worker/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: TRAVIS_WORKER_HOSTNAME
           value: $(POD_NAME).$(POD_NAMESPACE)
         - name: TRAVIS_WORKER_CONCURRENT_JOBS_NAME
-          values: $(POD_NAME)
+          value: $(POD_NAME)
 
         # The worker secret will have these prefixed with TRAVIS_WORKER,
         # but the AWS library wants these variable names instead.

--- a/charts/macstadium-worker/values.yaml
+++ b/charts/macstadium-worker/values.yaml
@@ -18,8 +18,15 @@ secretEnv: ""
 # Which travis-ci site this worker is for ("org" or "com")
 site: ""
 
-# How many concurrent jobs this worker can run
-poolSize: 2
+concurrency:
+  poolSize: 2
+
+  # The maximum number of jobs that should be able to run across all worker instances in this deployment
+  totalJobs: 10
+
+  redis:
+    # The service name of the Redis instance to connect to for tracking running jobs
+    name: ""
 
 # The AMQP queue to pull jobs from
 queue: builds.macstadium6

--- a/charts/redis/.helmignore
+++ b/charts/redis/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: redis
+version: 0.1.0

--- a/charts/redis/requirements.lock
+++ b/charts/redis/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 4.3.0
+digest: sha256:c1172ef9a6a591c731a2417ac5a3163ac41d673852e7f93b678321d28da25368
+generated: 2018-11-30T08:56:38.08434-06:00

--- a/charts/redis/requirements.yaml
+++ b/charts/redis/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: redis
+    version: "4.3.0"
+    repository: https://kubernetes-charts.storage.googleapis.com

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -1,0 +1,8 @@
+redis:
+  cluster:
+    enabled: false
+  usePassword: false
+
+  master:
+    persistence:
+      enabled: false

--- a/releases/macstadium-prod-1/worker-com.yaml
+++ b/releases/macstadium-prod-1/worker-com.yaml
@@ -20,7 +20,7 @@ spec:
       poolSize: 21
       totalJobs: 21 # eventually 105ish
       redis:
-        name: worker-redis
+        name: worker-redis-master
 
     jupiterBrainName: jupiter-brain-com
     secretEnv: production-common

--- a/releases/macstadium-prod-1/worker-com.yaml
+++ b/releases/macstadium-prod-1/worker-com.yaml
@@ -15,6 +15,12 @@ spec:
     # replicaCount: 5
     replicaCount: 1
     site: com
-    poolSize: 21
+
+    concurrency:
+      poolSize: 21
+      totalJobs: 21 # eventually 105ish
+      redis:
+        name: worker-redis
+
     jupiterBrainName: jupiter-brain-com
     secretEnv: production-common

--- a/releases/macstadium-prod-1/worker-org.yaml
+++ b/releases/macstadium-prod-1/worker-org.yaml
@@ -15,6 +15,12 @@ spec:
     # replicaCount: 8
     replicaCount: 1
     site: org
-    poolSize: 20
+
+    concurrency:
+      poolSize: 20
+      totalJobs: 20 # eventually 160ish
+      redis:
+        name: worker-redis
+
     jupiterBrainName: jupiter-brain-org
     secretEnv: production-common

--- a/releases/macstadium-prod-1/worker-org.yaml
+++ b/releases/macstadium-prod-1/worker-org.yaml
@@ -20,7 +20,7 @@ spec:
       poolSize: 20
       totalJobs: 20 # eventually 160ish
       redis:
-        name: worker-redis
+        name: worker-redis-master
 
     jupiterBrainName: jupiter-brain-org
     secretEnv: production-common

--- a/releases/macstadium-prod-1/worker-redis.yaml
+++ b/releases/macstadium-prod-1/worker-redis.yaml
@@ -1,0 +1,11 @@
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: worker-redis
+  namespace: macstadium-prod-1
+  labels:
+    chart: redis
+spec:
+  chartGitPath: redis
+  releaseName: worker-redis
+  values: {}

--- a/releases/macstadium-staging/worker-com.yaml
+++ b/releases/macstadium-staging/worker-com.yaml
@@ -18,7 +18,7 @@ spec:
       poolSize: 2
       totalJobs: 4 # this is artificially low for testing
       redis:
-        name: worker-redis
+        name: worker-redis-master
 
     jupiterBrainName: jupiter-brain-com
     secretEnv: staging-common

--- a/releases/macstadium-staging/worker-com.yaml
+++ b/releases/macstadium-staging/worker-com.yaml
@@ -10,9 +10,15 @@ spec:
   releaseName: worker-com
   values:
     image:
-      tag: v5.0.0
+      tag: v5.1.0-7-g620b1f9
     replicaCount: 4
     site: com
-    poolSize: 2
+
+    concurrency:
+      poolSize: 2
+      totalJobs: 4 # this is artificially low for testing
+      redis:
+        name: worker-redis
+
     jupiterBrainName: jupiter-brain-com
     secretEnv: staging-common

--- a/releases/macstadium-staging/worker-org.yaml
+++ b/releases/macstadium-staging/worker-org.yaml
@@ -10,9 +10,15 @@ spec:
   releaseName: worker-org
   values:
     image:
-      tag: v5.0.0
+      tag: v5.1.0-7-g620b1f9
     replicaCount: 4
     site: org
-    poolSize: 2
+
+    concurrency:
+      poolSize: 2
+      totalJobs: 4 # this is artificially low for testing
+      redis:
+        name: worker-redis
+
     jupiterBrainName: jupiter-brain-org
     secretEnv: staging-common

--- a/releases/macstadium-staging/worker-org.yaml
+++ b/releases/macstadium-staging/worker-org.yaml
@@ -18,7 +18,7 @@ spec:
       poolSize: 2
       totalJobs: 4 # this is artificially low for testing
       redis:
-        name: worker-redis
+        name: worker-redis-master
 
     jupiterBrainName: jupiter-brain-org
     secretEnv: staging-common

--- a/releases/macstadium-staging/worker-redis.yaml
+++ b/releases/macstadium-staging/worker-redis.yaml
@@ -1,0 +1,11 @@
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: worker-redis
+  namespace: macstadium-staging
+  labels:
+    chart: redis
+spec:
+  chartGitPath: redis
+  releaseName: worker-redis
+  values: {}

--- a/shared/install-flux.sh
+++ b/shared/install-flux.sh
@@ -9,6 +9,7 @@ fi
 
 helm repo add weaveworks https://weaveworks.github.io/flux
 helm upgrade flux weaveworks/flux \
+  --version 0.4.0 \
   --install \
   --set rbac.create=true \
   --set helmOperator.create=true \

--- a/shared/install-flux.sh
+++ b/shared/install-flux.sh
@@ -2,12 +2,18 @@
 
 NAMESPACE=$(kubectl config current-context)
 
+BRANCH="master"
+if [[ $NAMESPACE == *staging* ]]; then
+  BRANCH="staging"
+fi
+
 helm repo add weaveworks https://weaveworks.github.io/flux
 helm upgrade flux weaveworks/flux \
   --install \
   --set rbac.create=true \
   --set helmOperator.create=true \
   --set git.url=ssh://git@github.com/travis-ci/kubernetes-config.git \
+  --set "git.branch=$BRANCH" \
   --set "git.path=releases/$NAMESPACE" \
   --set git.chartsPath=charts \
   --set git.pollInterval=1m \


### PR DESCRIPTION
Fixes #5, I hope.

Add a small Redis Helm chart, which pulls in the Bitnami Redis chart and preconfigures it for our needs. Deploy that chart using Flux.

Add the necessary configuration for tracking concurrent jobs in Redis to worker. Use a very low total jobs number for staging so that it's easy to test this behavior even when we aren't running extra worker instances.

Production worker releases are configured correctly, but aren't pointing at a version of worker with this feature yet since there is no release for it quite yet.