### PR TITLE
Make more trvs secrets optional

### DIFF
--- a/charts/macstadium-worker/templates/_helpers.tpl
+++ b/charts/macstadium-worker/templates/_helpers.tpl
@@ -34,3 +34,14 @@ Create chart name and version as used by the chart label.
 {{- define "macstadium-worker.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Use the fullname as the secret name unless a secretName has been provided.
+*/}}
+{{- define "macstadium-worker.secret" -}}
+{{- if .Values.secretName -}}
+{{- .Values.secretName -}}
+{{- else -}}
+{{- include "macstadium-worker.fullname" . }}
+{{- end -}}
+{{- end -}}

--- a/charts/macstadium-worker/templates/deployment.yaml
+++ b/charts/macstadium-worker/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
         - configMapRef:
             name: {{ template "macstadium-worker.fullname" . }}
         - secretRef:
-            name: {{ template "macstadium-worker.fullname" . }}
+            name: {{ template "macstadium-worker.secret" . }}
         volumeMounts:
         - name: travis-vm-ssh-key
           mountPath: "/etc/secret"

--- a/charts/macstadium-worker/templates/secret.yaml
+++ b/charts/macstadium-worker/templates/secret.yaml
@@ -1,14 +1,16 @@
+{{- if .Values.trvs.enabled }}
 apiVersion: travisci.com/v1
 kind: TrvsSecret
 metadata:
-  name: {{ include "macstadium-worker.fullname" . }}
+  name: {{ include "macstadium-worker.secret" . }}
   labels:
     app.kubernetes.io/name: {{ include "macstadium-worker.name" . }}
     helm.sh/chart: {{ include "macstadium-worker.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  app: macstadium-workers
-  env: {{ .Values.secretEnv }}
+  app: {{ .Values.trvs.app }}
+  env: {{ .Values.trvs.env }}
   prefix: TRAVIS_WORKER
-  pro: {{ eq .Values.site "com" }}
+  pro: {{ eq .Values.trvs.pro }}
+{{- end }}

--- a/charts/macstadium-worker/templates/secret.yaml
+++ b/charts/macstadium-worker/templates/secret.yaml
@@ -12,5 +12,5 @@ spec:
   app: {{ .Values.trvs.app }}
   env: {{ .Values.trvs.env }}
   prefix: TRAVIS_WORKER
-  pro: {{ eq .Values.trvs.pro }}
+  pro: {{ .Values.trvs.pro }}
 {{- end }}

--- a/charts/macstadium-worker/values.yaml
+++ b/charts/macstadium-worker/values.yaml
@@ -12,8 +12,23 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-# The environment to pull configuration from in the keychain
-secretEnv: ""
+# Pull secrets from trvs keychain
+trvs:
+  # If not enabled, be sure to set secretName and create a secret with the
+  # necessary environment variables for worker
+  enabled: false
+  app: ""  # Different infras use a different app key for their secrets
+  env: ""
+  pro: false
+
+# Override the name of the secret with environment variables.
+#
+# If trvs.enabled is true, it will create a secret with this name instead
+# of using the fullname of the deployment.
+#
+# If trvs.enabled is false, this should be set and you must create a secret
+# with the given name that has the right environment variables.
+secretName: ""
 
 # Which travis-ci site this worker is for ("org" or "com")
 site: ""

--- a/charts/vsphere-janitor/templates/_helpers.tpl
+++ b/charts/vsphere-janitor/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "vsphere-janitor.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Use the fullname as the secret name unless a secretName has been provided.
+*/}}
+{{- define "vsphere-janitor.secret" -}}
+{{- if .Values.secretName -}}
+{{- .Values.secretName -}}
+{{- else -}}
+{{- include "vsphere-janitor.fullname" . }}
+{{- end -}}
+{{- end -}}

--- a/charts/vsphere-janitor/templates/deployment.yaml
+++ b/charts/vsphere-janitor/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             value: $(POD_NAMESPACE)-$(POD_NAME)
           envFrom:
           - secretRef:
-              name: {{ include "vsphere-janitor.fullname" . }}
+              name: {{ include "vsphere-janitor.secret" . }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/charts/vsphere-janitor/templates/secret.yaml
+++ b/charts/vsphere-janitor/templates/secret.yaml
@@ -1,14 +1,16 @@
+{{- if .Values.trvs.enabled }}
 apiVersion: travisci.com/v1
 kind: TrvsSecret
 metadata:
-  name: {{ include "vsphere-janitor.fullname" . }}
+  name: {{ include "vsphere-janitor.secret" . }}
   labels:
     app.kubernetes.io/name: {{ include "vsphere-janitor.name" . }}
     helm.sh/chart: {{ include "vsphere-janitor.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  app: vsphere-janitor
-  env: {{ .Values.secretEnv }}
+  app: {{ .Values.trvs.app }}
+  env: {{ .Values.trvs.env }}
   prefix: VSPHERE_JANITOR
-  pro: true
+  pro: {{ .Values.trvs.pro }}
+{{- end }}

--- a/charts/vsphere-janitor/values.yaml
+++ b/charts/vsphere-janitor/values.yaml
@@ -10,7 +10,23 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-secretEnv: ""
+# Pull secrets from trvs keychain
+trvs:
+  # If not enabled, be sure to set secretName and create a secret with the
+  # necessary environment variables for vsphere-janitor
+  enabled: false
+  app: vsphere-janitor
+  env: ""
+  pro: true
+
+# Override the name of the secret with environment variables.
+#
+# If trvs.enabled is true, it will create a secret with this name instead
+# of using the fullname of the deployment.
+#
+# If trvs.enabled is false, this should be set and you must create a secret
+# with the given name that has the right environment variables.
+secretName: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/vsphere-monitor/templates/_helpers.tpl
+++ b/charts/vsphere-monitor/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "vsphere-monitor.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Use the fullname as the secret name unless a secretName has been provided.
+*/}}
+{{- define "vsphere-monitor.secret" -}}
+{{- if .Values.secretName -}}
+{{- .Values.secretName -}}
+{{- else -}}
+{{- include "vsphere-monitor.fullname" . }}
+{{- end -}}
+{{- end -}}

--- a/charts/vsphere-monitor/templates/deployment.yaml
+++ b/charts/vsphere-monitor/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: {{ include "vsphere-monitor.fullname" . }}
+                name: {{ include "vsphere-monitor.secret" . }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/charts/vsphere-monitor/templates/secret.yaml
+++ b/charts/vsphere-monitor/templates/secret.yaml
@@ -1,13 +1,16 @@
+{{- if .Values.trvs.enabled }}
 apiVersion: travisci.com/v1
 kind: TrvsSecret
 metadata:
-  name: {{ include "vsphere-monitor.fullname" . }}
+  name: {{ include "vsphere-monitor.secret" . }}
   labels:
     app.kubernetes.io/name: {{ include "vsphere-monitor.name" . }}
     helm.sh/chart: {{ include "vsphere-monitor.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  app: vsphere-monitor
-  env: {{ .Values.secretEnv }}
+  app: {{ .Values.trvs.app }}
+  env: {{ .Values.trvs.env }}
   prefix: VSPHERE_MONITOR
+  pro: {{ .Values.trvs.pro }}
+{{- end }}

--- a/charts/vsphere-monitor/values.yaml
+++ b/charts/vsphere-monitor/values.yaml
@@ -10,7 +10,23 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-secretEnv: ""
+# Pull secrets from trvs keychain
+trvs:
+  # If not enabled, be sure to set secretName and create a secret with the
+  # necessary environment variables for vsphere-monitor
+  enabled: false
+  app: vsphere-monitor
+  env: ""
+  pro: false
+
+# Override the name of the secret with environment variables.
+#
+# If trvs.enabled is true, it will create a secret with this name instead
+# of using the fullname of the deployment.
+#
+# If trvs.enabled is false, this should be set and you must create a secret
+# with the given name that has the right environment variables.
+secretName: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/releases/macstadium-prod-1/worker-com.yaml
+++ b/releases/macstadium-prod-1/worker-com.yaml
@@ -17,4 +17,8 @@ spec:
     site: com
     poolSize: 21
     jupiterBrainName: jupiter-brain-com
-    secretEnv: production-common
+    trvs:
+      enabled: true
+      app: macstadium-workers
+      env: production-common
+      pro: true

--- a/releases/macstadium-prod-1/worker-org.yaml
+++ b/releases/macstadium-prod-1/worker-org.yaml
@@ -17,4 +17,7 @@ spec:
     site: org
     poolSize: 20
     jupiterBrainName: jupiter-brain-org
-    secretEnv: production-common
+    trvs:
+      enabled: true
+      app: macstadium-workers
+      env: production-common

--- a/releases/macstadium-staging/vsphere-janitor.yaml
+++ b/releases/macstadium-staging/vsphere-janitor.yaml
@@ -9,4 +9,6 @@ spec:
   chartGitPath: vsphere-janitor
   releaseName: vsphere-janitor
   values:
-    secretEnv: staging-1
+    trvs:
+      enabled: true
+      env: staging-1

--- a/releases/macstadium-staging/vsphere-monitor.yaml
+++ b/releases/macstadium-staging/vsphere-monitor.yaml
@@ -9,4 +9,6 @@ spec:
   chartGitPath: vsphere-monitor
   releaseName: vsphere-monitor
   values:
-    secretEnv: common-1
+    trvs:
+      enabled: true
+      env: common-1

--- a/releases/macstadium-staging/worker-com.yaml
+++ b/releases/macstadium-staging/worker-com.yaml
@@ -15,4 +15,8 @@ spec:
     site: com
     poolSize: 2
     jupiterBrainName: jupiter-brain-com
-    secretEnv: staging-common
+    trvs:
+      enabled: true
+      app: macstadium-workers
+      env: staging-common
+      pro: true

--- a/releases/macstadium-staging/worker-org.yaml
+++ b/releases/macstadium-staging/worker-org.yaml
@@ -15,4 +15,7 @@ spec:
     site: org
     poolSize: 2
     jupiterBrainName: jupiter-brain-org
-    secretEnv: staging-common
+    trvs:
+      enabled: true
+      app: macstadium-workers
+      env: staging-common


### PR DESCRIPTION
This updates several charts to make the `TrvsSecret` resource optional, controlled by the `trvs.enabled` key in the values. Updated charts in this PR: 

* macstadium-worker
* vsphere-janitor
* vsphere-monitor

This makes it possible to deploy these charts in situations like Enterprise where `trvs` would not/could not be used. Whoever is deploying the chart just needs to provide a `secretName` value and create their own Kubernetes secret with the environment variables needed.

Fixes #14.