### PR TITLE
Deploy kubernetes-dashboard with Flux

### DIFF
--- a/releases/macstadium-prod-1/kubernetes-dashboard.yaml
+++ b/releases/macstadium-prod-1/kubernetes-dashboard.yaml
@@ -1,0 +1,17 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  chart:
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    name: kubernetes-dashboard
+    version: "0.8.0"
+  releaseName: kubernetes-dashboard
+  values:
+    service:
+      type: NodePort
+      nodePort: 31000
+    rbac:
+      clusterAdminRole: true

--- a/releases/macstadium-staging/kubernetes-dashboard.yaml
+++ b/releases/macstadium-staging/kubernetes-dashboard.yaml
@@ -1,0 +1,17 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  chart:
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    name: kubernetes-dashboard
+    version: "0.8.0"
+  releaseName: kubernetes-dashboard
+  values:
+    service:
+      type: NodePort
+      nodePort: 31000
+    rbac:
+      clusterAdminRole: true

--- a/shared/install-dashboard-macstadium.sh
+++ b/shared/install-dashboard-macstadium.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-TOP=$(git rev-parse --show-toplevel)
-
-helm install stable/kubernetes-dashboard \
-  --values "$TOP/shared/macstadium-dashboard-values.yaml" \
-  --name kubernetes-dashboard \
-  --namespace kube-system

--- a/shared/macstadium-dashboard-values.yaml
+++ b/shared/macstadium-dashboard-values.yaml
@@ -1,6 +1,0 @@
-service:
-  type: NodePort
-  nodePort: 31000
-
-rbac:
-  clusterAdminRole: true


### PR DESCRIPTION
Now that we can easily use Flux to install a pre-packaged Helm chart (#28), it makes sense to do this for the Kubernetes Dashboard and get rid of the custom script to install it.