### PR TITLE
Add rake task to render templates for all releases

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,7 @@
-task default: %i[lint package]
+require 'open3'
+require 'yaml'
+
+task default: %i[lint validate package]
 
 CHARTS = FileList["charts/*"].resolve
 
@@ -15,5 +18,39 @@ task :package do
       sh "helm package -u ../#{chart}"
     end
     sh "helm repo index . --url https://travis-ci-helm-charts.storage.googleapis.com"
+  end
+end
+
+RELEASES = FileList["releases/**/*.yaml"]
+
+task :validate do
+  RELEASES.each do |release|
+    validate_release(release)
+  end
+end
+
+def validate_release(release)
+  r = YAML.safe_load(File.read(release))
+  return unless r['spec']['chart']['git'] == 'git@github.com:travis-ci/kubernetes-config.git'
+
+  namespace = r['metadata']['namespace']
+  release_name = r['spec']['releaseName']
+  chart_path = r['spec']['chart']['path']
+  values = r['spec']['values']
+
+  Open3.popen2e('helm', 'template', chart_path, '-n', release_name, '--namespace', namespace, '-f', '-') do |stdin, output, wait|
+    stdin.write(YAML.dump(values))
+    stdin.close
+
+    out = output.read
+
+    status = wait.value
+    if status.success?
+      puts "Release #{release} rendered successfully."
+    else
+      puts "Release #{release} failed to render. Output from helm:"
+      puts out
+      exit 1
+    end
   end
 end


### PR DESCRIPTION
Fixes #31.

This adds a rake task to the Travis CI build that will render the chart templates using the values that we configure in the HelmRelease resources. This can catch a certain class of error in the Helm templates and surface it in CI.

Without this change, making an error in the templates will cause Flux to silently not be able to deploy the release. You can dig in the logs of the `flux-helm-operator` pod and find the error message if you remember to look for it. It's better to surface these failures on PRs and such.