### PR TITLE
Add worker and jupiter-brain for custom-2

### DIFF
--- a/releases/macstadium-prod-1/jupiter-brain-custom-2.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-custom-2.yaml
@@ -1,0 +1,17 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: jupiter-brain-custom-2
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/jupiter-brain
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: jupiter-brain-custom-2
+  values:
+    trvs:
+      enabled: true
+      env: custom-2-1
+    honeycomb:
+      dataset: jb-requests
+      sampleRate: 1

--- a/releases/macstadium-prod-1/worker-custom-2.yaml
+++ b/releases/macstadium-prod-1/worker-custom-2.yaml
@@ -1,0 +1,22 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: worker-custom-2
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/macstadium-worker
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: worker-custom-2
+  values:
+    image:
+      tag: v6.1.0
+    replicaCount: 1
+    site: com
+    poolSize: 5
+    jupiterBrainName: jupiter-brain-custom-2
+    trvs:
+      enabled: true
+      app: macstadium-workers
+      env: production-common
+      pro: true


### PR DESCRIPTION
One of the custom-2 workers needs to be moved from .org to .com, so I think this is an opportunity to just bring it up on the Kubernetes cluster. This involves just configuring a worker and jupiter-brain for this instance.