### PR TITLE
Migrate production workers to worker-operator cluster

### DIFF
--- a/releases/macstadium-prod-1/worker-com.yaml
+++ b/releases/macstadium-prod-1/worker-com.yaml
@@ -10,13 +10,16 @@ spec:
   releaseName: worker-com
   values:
     image:
-      tag: v5.0.0
-    # Eventually this should be:
-    # replicaCount: 5
-    replicaCount: 1
+      tag: v6.2.0
+
+    cluster:
+      enabled: true
+      maxJobs: 21
+      maxJobsPerWorker: 20
+
     site: com
-    poolSize: 21
     jupiterBrainName: jupiter-brain-com
+
     trvs:
       enabled: true
       app: macstadium-workers

--- a/releases/macstadium-prod-1/worker-custom-2.yaml
+++ b/releases/macstadium-prod-1/worker-custom-2.yaml
@@ -10,12 +10,17 @@ spec:
   releaseName: worker-custom-2
   values:
     image:
-      tag: v6.1.0
-    replicaCount: 1
+      tag: v6.2.0
+
+    cluster:
+      enabled: true
+      maxJobs: 5
+      maxJobsPerWorker: 5
+
     site: com
-    poolSize: 5
     jupiterBrainName: jupiter-brain-custom-2
     queue: ""
+
     trvs:
       enabled: true
       app: macstadium-workers

--- a/releases/macstadium-prod-1/worker-org.yaml
+++ b/releases/macstadium-prod-1/worker-org.yaml
@@ -10,13 +10,16 @@ spec:
   releaseName: worker-org
   values:
     image:
-      tag: v5.0.0
-    # Eventually this should be:
-    # replicaCount: 8
-    replicaCount: 1
+      tag: v6.2.0
+
+    cluster:
+      enabled: true
+      maxJobs: 25
+      maxJobsPerWorker: 20
+
     site: org
-    poolSize: 20
     jupiterBrainName: jupiter-brain-org
+
     trvs:
       enabled: true
       app: macstadium-workers

--- a/releases/macstadium-staging/worker-com.yaml
+++ b/releases/macstadium-staging/worker-com.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: worker-com
   values:
     image:
-      tag: v6.0.0
+      tag: v6.2.0
 
     cluster:
       enabled: true

--- a/releases/macstadium-staging/worker-org.yaml
+++ b/releases/macstadium-staging/worker-org.yaml
@@ -11,7 +11,7 @@ spec:
   releaseName: worker-org
   values:
     image:
-      tag: v6.0.0
+      tag: v6.2.0
 
     cluster:
       enabled: true


### PR DESCRIPTION
It would be nice to be able to flexibly scale pool sizes in our production workloads, and we need the worker-operator to be able to do that.

Also bumping the version of the staging workers.