### PR TITLE
Add capacity from terraform workers

### DIFF
--- a/releases/macstadium-prod-1/worker-com.yaml
+++ b/releases/macstadium-prod-1/worker-com.yaml
@@ -14,7 +14,7 @@ spec:
 
     cluster:
       enabled: true
-      maxJobs: 21
+      maxJobs: 56
       maxJobsPerWorker: 20
 
     site: com

--- a/releases/macstadium-prod-1/worker-org.yaml
+++ b/releases/macstadium-prod-1/worker-org.yaml
@@ -14,7 +14,7 @@ spec:
 
     cluster:
       enabled: true
-      maxJobs: 25
+      maxJobs: 54
       maxJobsPerWorker: 20
 
     site: org


### PR DESCRIPTION
This will also shift 30 jobs from .org to .com overall. It's a rough guess at a good place to start moving that capacity.

The capacity is removed from the old wjb workers in https://github.com/travis-ci/terraform-config/pull/654.