### PR TITLE
Add vsphere-monitor and vsphere-janitor for macstadium-prod-1

### DIFF
--- a/releases/macstadium-prod-1/vsphere-janitor.yaml
+++ b/releases/macstadium-prod-1/vsphere-janitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: vsphere-janitor
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/vsphere-janitor
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: vsphere-janitor
+  values:
+    trvs:
+      enabled: true
+      env: production-1

--- a/releases/macstadium-prod-1/vsphere-monitor.yaml
+++ b/releases/macstadium-prod-1/vsphere-monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: vsphere-monitor
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/vsphere-monitor
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: vsphere-monitor
+  values:
+    trvs:
+      enabled: true
+      env: common-1


### PR DESCRIPTION
These services are already running in macstadium-staging, but are currently running on wjb-1 in production. I want move them from wjb-1 to the Kubernetes cluster.