### PR TITLE
Migrate remaining custom workers to cluster

### DIFF
--- a/releases/macstadium-prod-1/jupiter-brain-custom-1.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-custom-1.yaml
@@ -1,0 +1,17 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: jupiter-brain-custom-1
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/jupiter-brain
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: jupiter-brain-custom-1
+  values:
+    trvs:
+      enabled: true
+      env: custom-1-1
+    honeycomb:
+      dataset: jb-requests
+      sampleRate: 1

--- a/releases/macstadium-prod-1/jupiter-brain-custom-4.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-custom-4.yaml
@@ -1,0 +1,17 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: jupiter-brain-custom-4
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/jupiter-brain
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: jupiter-brain-custom-4
+  values:
+    trvs:
+      enabled: true
+      env: custom-4-1
+    honeycomb:
+      dataset: jb-requests
+      sampleRate: 1

--- a/releases/macstadium-prod-1/jupiter-brain-custom-5.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-custom-5.yaml
@@ -1,0 +1,17 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: jupiter-brain-custom-5
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/jupiter-brain
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: jupiter-brain-custom-5
+  values:
+    trvs:
+      enabled: true
+      env: custom-5-1
+    honeycomb:
+      dataset: jb-requests
+      sampleRate: 1

--- a/releases/macstadium-prod-1/jupiter-brain-custom-6.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-custom-6.yaml
@@ -1,0 +1,18 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: jupiter-brain-custom-6
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/jupiter-brain
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: jupiter-brain-custom-6
+  values:
+    trvs:
+      enabled: true
+      env: custom-6-1
+      pro: true
+    honeycomb:
+      dataset: jb-requests
+      sampleRate: 1

--- a/releases/macstadium-prod-1/vsphere-janitor-custom-1.yaml
+++ b/releases/macstadium-prod-1/vsphere-janitor-custom-1.yaml
@@ -1,0 +1,15 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: vsphere-janitor-custom-1
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/vsphere-janitor
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: vsphere-janitor-custom-1
+  values:
+    trvs:
+      enabled: true
+      env: custom-1-1
+      pro: false

--- a/releases/macstadium-prod-1/vsphere-janitor-custom-4.yaml
+++ b/releases/macstadium-prod-1/vsphere-janitor-custom-4.yaml
@@ -1,0 +1,15 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: vsphere-janitor-custom-4
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/vsphere-janitor
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: vsphere-janitor-custom-4
+  values:
+    trvs:
+      enabled: true
+      env: custom-4-1
+      pro: false

--- a/releases/macstadium-prod-1/vsphere-janitor-custom-5.yaml
+++ b/releases/macstadium-prod-1/vsphere-janitor-custom-5.yaml
@@ -1,0 +1,15 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: vsphere-janitor-custom-5
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/vsphere-janitor
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: vsphere-janitor-custom-5
+  values:
+    trvs:
+      enabled: true
+      env: custom-5-1
+      pro: false

--- a/releases/macstadium-prod-1/vsphere-janitor-custom-6.yaml
+++ b/releases/macstadium-prod-1/vsphere-janitor-custom-6.yaml
@@ -1,0 +1,15 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: vsphere-janitor-custom-6
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/vsphere-janitor
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: vsphere-janitor-custom-6
+  values:
+    trvs:
+      enabled: true
+      env: custom-6-1
+      pro: true

--- a/releases/macstadium-prod-1/worker-custom-1.yaml
+++ b/releases/macstadium-prod-1/worker-custom-1.yaml
@@ -1,0 +1,27 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: worker-custom-1
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/macstadium-worker
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: worker-custom-1
+  values:
+    image:
+      tag: v6.2.0
+
+    cluster:
+      enabled: true
+      maxJobs: 5
+      maxJobsPerWorker: 5
+
+    site: org
+    jupiterBrainName: jupiter-brain-custom-1
+    queue: ""
+
+    trvs:
+      enabled: true
+      app: macstadium-workers
+      env: custom-1

--- a/releases/macstadium-prod-1/worker-custom-4.yaml
+++ b/releases/macstadium-prod-1/worker-custom-4.yaml
@@ -1,0 +1,27 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: worker-custom-4
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/macstadium-worker
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: worker-custom-4
+  values:
+    image:
+      tag: v6.2.0
+
+    cluster:
+      enabled: true
+      maxJobs: 5
+      maxJobsPerWorker: 5
+
+    site: org
+    jupiterBrainName: jupiter-brain-custom-4
+    queue: ""
+
+    trvs:
+      enabled: true
+      app: macstadium-workers
+      env: custom-4

--- a/releases/macstadium-prod-1/worker-custom-5.yaml
+++ b/releases/macstadium-prod-1/worker-custom-5.yaml
@@ -1,0 +1,27 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: worker-custom-5
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/macstadium-worker
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: worker-custom-5
+  values:
+    image:
+      tag: v6.2.0
+
+    cluster:
+      enabled: true
+      maxJobs: 5
+      maxJobsPerWorker: 5
+
+    site: org
+    jupiterBrainName: jupiter-brain-custom-5
+    queue: ""
+
+    trvs:
+      enabled: true
+      app: macstadium-workers
+      env: custom-5

--- a/releases/macstadium-prod-1/worker-custom-6.yaml
+++ b/releases/macstadium-prod-1/worker-custom-6.yaml
@@ -1,0 +1,28 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: worker-custom-6
+  namespace: macstadium-prod-1
+spec:
+  chart:
+    path: charts/macstadium-worker
+    git: git@github.com:travis-ci/kubernetes-config.git
+  releaseName: worker-custom-6
+  values:
+    image:
+      tag: v6.2.0
+
+    cluster:
+      enabled: true
+      maxJobs: 5
+      maxJobsPerWorker: 5
+
+    site: com
+    jupiterBrainName: jupiter-brain-custom-6
+    queue: ""
+
+    trvs:
+      enabled: true
+      app: macstadium-workers
+      env: custom-6
+      pro: true


### PR DESCRIPTION
As part of the gradual process of moving things from wjb-1 over to the Kubernetes cluster, this brings up the following processes for the remaining custom workers (custom-2 is already here):

* worker
* jupiter-brain
* vsphere-janitor