### PR TITLE
Add gcloud-cleanup chart and release

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ helm create charts/my-new-service
 
 ### Releases
 
-The `releases` directory has subdirectories for each environment that we deploy to (e.g. `macstadium-staging`). The name should match up to the Terraform graph directory that provisions the cluster.
+The `releases` directory has subdirectories for each environment that we deploy to (e.g. `macstadium-staging`). The name should match up to the Terraform graph directory that provisions the cluster. For Google Kubernetes Engine, the naming is more complicated, the name can be found with `kubectl config current-context`.
 
 Inside a particular environment's releases directory are YAML files for the different Helm releases that will be deployed to the environment. Each chart deployed to an environment will have its own release where it can be customized as needed.
 

--- a/charts/gcloud-cleanup/.helmignore
+++ b/charts/gcloud-cleanup/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/gcloud-cleanup/Chart.yaml
+++ b/charts/gcloud-cleanup/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: gcloud-cleanup
+version: 0.0.1

--- a/charts/gcloud-cleanup/README.txt
+++ b/charts/gcloud-cleanup/README.txt
@@ -1,0 +1,9 @@
+# gcloud-cleanup chart
+
+This chart installs [gcloud-cleanup](https://github.com/travis-ci/gcloud-cleanup) on kubernetes. The environment variables are set through [trvs-operator](https://github.com/travis-ci/trvs-operator/) which in turn gets it from the super secret keychain.
+
+## Installation
+
+```bash
+helm upgrade --install --set trvs.enabled=true,trvs.env=staging-1 .
+```

--- a/charts/gcloud-cleanup/templates/NOTES.txt
+++ b/charts/gcloud-cleanup/templates/NOTES.txt
@@ -1,0 +1,3 @@
+See the logs of this pod:
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "gcloud-cleanup.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl logs -f $POD_NAME

--- a/charts/gcloud-cleanup/templates/_helpers.tpl
+++ b/charts/gcloud-cleanup/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gcloud-cleanup.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gcloud-cleanup.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gcloud-cleanup.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Use the fullname as the secret name unless a secretName has been provided.
+*/}}
+{{- define "gcloud-cleanup.secret" -}}
+{{- if .Values.secretName -}}
+{{- .Values.secretName -}}
+{{- else -}}
+{{- include "gcloud-cleanup.fullname" . }}
+{{- end -}}
+{{- end -}}

--- a/charts/gcloud-cleanup/templates/deployment.yaml
+++ b/charts/gcloud-cleanup/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gcloud-cleanup.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "gcloud-cleanup.name" . }}
+    helm.sh/chart: {{ include "gcloud-cleanup.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "gcloud-cleanup.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "gcloud-cleanup.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          livenessProbe:
+            exec:
+              command:
+                - ps | grep [g]cloud-cleanup
+            initialDelaySeconds: 10
+            periodSeconds: 130
+          env:
+            {{ range $key, $value := .Values.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+            {{ end }}
+          envFrom:
+            - secretRef:
+                name: {{ template "gcloud-cleanup.secret" . }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/gcloud-cleanup/templates/secret.yaml
+++ b/charts/gcloud-cleanup/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.trvs.enabled }}
+apiVersion: travisci.com/v1
+kind: TrvsSecret
+metadata:
+  name: {{ include "gcloud-cleanup.secret" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "gcloud-cleanup.name" . }}
+    helm.sh/chart: {{ include "gcloud-cleanup.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  app: {{ .Values.trvs.app }}
+  env: {{ .Values.trvs.env }}
+  prefix: GCLOUD_CLEANUP
+  pro: {{ .Values.trvs.pro }}
+{{- end }}

--- a/charts/gcloud-cleanup/values.yaml
+++ b/charts/gcloud-cleanup/values.yaml
@@ -1,0 +1,26 @@
+# Default values for gcloud-cleanup.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: travisci/gcloud-cleanup
+  tag: ''
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Pull secrets from trvs keychain
+trvs:
+  # If not enabled, be sure to set secretName and create a secret with the
+  # necessary environment variables for gcloud-cleanup
+  enabled: false
+  app: "gcloud-cleanup"
+  env: ""
+  pro: false
+
+secretName: ""
+
+env: []

--- a/releases/gke_travis-staging-1_us-central1-a_gce-staging-1/gcloud-cleanup.yaml
+++ b/releases/gke_travis-staging-1_us-central1-a_gce-staging-1/gcloud-cleanup.yaml
@@ -16,7 +16,7 @@ spec:
   values:
     image:
       repository: travisci/gcloud-cleanup
-      tag: afc3bd5
+      tag: b28c85d
     trvs:
       enabled: true
       env: staging-1

--- a/releases/gke_travis-staging-1_us-central1-a_gce-staging-1/gcloud-cleanup.yaml
+++ b/releases/gke_travis-staging-1_us-central1-a_gce-staging-1/gcloud-cleanup.yaml
@@ -16,7 +16,7 @@ spec:
   values:
     image:
       repository: travisci/gcloud-cleanup
-      tag: test-b4bd2fa
+      tag: afc3bd5
     trvs:
       enabled: true
       env: staging-1

--- a/releases/gke_travis-staging-1_us-central1-a_gce-staging-1/gcloud-cleanup.yaml
+++ b/releases/gke_travis-staging-1_us-central1-a_gce-staging-1/gcloud-cleanup.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: gcloud-cleanup
+  namespace: gce-staging-1
+  annotations:
+    flux.weave.works/tag.gcloud-cleanup: glob:test-*
+    flux.weave.works/automated: 'false'
+spec:
+  chart:
+    path: charts/gcloud-cleanup
+    git: git@github.com:travis-ci/kubernetes-config.git
+    ref: gcloud-test
+  releaseName: gcloud-cleanup
+  values:
+    image:
+      repository: travisci/gcloud-cleanup
+      tag: test-b4bd2fa
+    trvs:
+      enabled: true
+      env: staging-1
+      pro: false

--- a/shared/install-flux.sh
+++ b/shared/install-flux.sh
@@ -6,6 +6,7 @@ BRANCH="master"
 if [[ $NAMESPACE == *staging* ]]; then
   BRANCH="staging"
 fi
+BRANCH="gcloud-test"
 
 helm repo add weaveworks https://weaveworks.github.io/flux
 helm upgrade flux weaveworks/flux \

--- a/shared/install-flux.sh
+++ b/shared/install-flux.sh
@@ -17,4 +17,5 @@ helm upgrade flux weaveworks/flux \
   --set git.branch="$BRANCH" \
   --set "git.path=releases/$NAMESPACE" \
   --set git.pollInterval=1m \
+  --set git.label="flux-sync-$NAMESPACE" \
   --namespace flux


### PR DESCRIPTION
The PR adds the gcloud-cleanup chart and a corresponding release for the GKE staging cluster.

#### The gcloud-cleanup chart

This chart gives us an example on how to move apps from Heroku to GKE. As Heroku apps are run according to the 12-factor method, at minimum we should be able to set environment variables in the containers. The can be done in numerous ways, I've implement 2 options:

1. `values.env: {}` in the chart, the variables can be set like `values.env.ENV_VARIABLE` in the chart or in a release. This method doesn't require a ConfigMap, I'm not sure if this is the best way to go.
2. Using `trvs-operator` and pull the config variables in `travis-keychain`. This way we keep the `kubernetes-config` repo clean and free from application specific config.

I've chosen these 2 options as I think are fairly clean solutions, the first can be used for Kubernetes/infra related configuration, the latter for application specific configuration.

#### Cluster setup

These are the steps I've used to setup the cluster on GKE. It touches multiple repositories and I want to document it somewhere but I haven't found a good place for it yet. As the installation requires a non-trivial setup from `trvs-operator`, this will be a bit harder to automate.

Related code:
https://github.com/travis-ci/terraform-config/tree/name_gke_cluster
https://github.com/travis-ci/trvs-operator

Run in `terraform-config/gce-staging-1/`
- optional: add `-target module.gke_staging_cluster_1` to the make target to limit the scope
```
make clean plan
make apply
make context
```

Run in `kubernetes-config/`

```
./shared/install-tiller.sh
```

Run in `trvs-operator/`
```
kubectl create namespace gce-staging-1
./bin/install-trvs-operator.sh
```

Run in `kubernetes-config/`
> note: Using pbcopy for macOS, might want to replace with your OS equivalent.
```
ls releases/$(kubectl config current-context)
./shared/install-flux.sh
kubectl -n flux logs deployment/flux | grep identity.pub | cut -d '"' -f2 | pbcopy
```
- Add this key to https://github.com/travis-ci/kubernetes-config/settings/keys

Fluxctl can now be used to do releases, this is probably the way to go to building a ChatOps bot that does the releases.
```
fluxctl release --k8s-fwd-ns=flux --workload=gce-staging-1:helmrelease/gcloud-cleanup --update-image=travisci/gcloud-cleanup:afc3bd5
```

Must read docs on Flux/HelmRelease here: https://github.com/weaveworks/flux/blob/master/site/helm-integration.md