### PR TITLE
Include a Redis container for gcloud-cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,12 @@ CHARTS = FileList["charts/*"].resolve
 
 task :lint do
   CHARTS.each do |chart|
+    sh "helm dependency update #{chart}"
+  end
+end
+
+task :lint do
+  CHARTS.each do |chart|
     sh "helm lint #{chart}"
   end
 end

--- a/charts/gcloud-cleanup/requirements.lock
+++ b/charts/gcloud-cleanup/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 8.0.13
+digest: sha256:7585b1894ebb75ba58aad929d725fe673e2e0dbac3f9ee3b38b5d192b555a5f6
+generated: 2019-06-28T13:47:32.320609+02:00

--- a/charts/gcloud-cleanup/requirements.yaml
+++ b/charts/gcloud-cleanup/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: redis
+  version: 8.0.13
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: redis.enabled

--- a/charts/gcloud-cleanup/templates/_helpers.tpl
+++ b/charts/gcloud-cleanup/templates/_helpers.tpl
@@ -41,3 +41,7 @@ Use the fullname as the secret name unless a secretName has been provided.
 {{- include "gcloud-cleanup.fullname" . }}
 {{- end -}}
 {{- end -}}
+
+{{- define "gcloud-cleanup.redis.fullname" -}}
+{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/gcloud-cleanup/templates/deployment.yaml
+++ b/charts/gcloud-cleanup/templates/deployment.yaml
@@ -34,6 +34,13 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
             {{ end }}
+            - name: GCLOUD_CLEANUP_RATE_LIMIT_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "gcloud-cleanup.redis.fullname" . }}
+                  key: redis-password
+            - name: GCLOUD_CLEANUP_RATE_LIMIT_REDIS_URL
+              value: redis://:$(GCLOUD_CLEANUP_RATE_LIMIT_REDIS_PASSWORD)@$(GCLOUD_CLEANUP_REDIS_MASTER_SERVICE_HOST):$(GCLOUD_CLEANUP_REDIS_MASTER_SERVICE_PORT)
           envFrom:
             - secretRef:
                 name: {{ template "gcloud-cleanup.secret" . }}

--- a/charts/gcloud-cleanup/templates/deployment.yaml
+++ b/charts/gcloud-cleanup/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
             {{ end }}
+          {{- if .Values.redis.enabled }}
             - name: GCLOUD_CLEANUP_RATE_LIMIT_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -44,6 +45,7 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ template "gcloud-cleanup.secret" . }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/gcloud-cleanup/values.yaml
+++ b/charts/gcloud-cleanup/values.yaml
@@ -25,5 +25,11 @@ secretName: ""
 
 redis:
   enabled: false
+  cluster:
+    enabled: false
+  master:
+    persistence:
+      enabled: false
+
 
 env: []

--- a/charts/gcloud-cleanup/values.yaml
+++ b/charts/gcloud-cleanup/values.yaml
@@ -23,4 +23,7 @@ trvs:
 
 secretName: ""
 
+redis:
+  enabled: false
+
 env: []

--- a/releases/gke_eco-emissary-99515_us-central1-a_gce-production-1-vpc-enabled/gcloud-cleanup.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1-a_gce-production-1-vpc-enabled/gcloud-cleanup.yaml
@@ -21,3 +21,5 @@ spec:
       enabled: true
       env: production-1
       pro: false
+    redis:
+      enabled: false

--- a/releases/gke_travis-staging-1_us-central1-a_gce-staging-1/gcloud-cleanup.yaml
+++ b/releases/gke_travis-staging-1_us-central1-a_gce-staging-1/gcloud-cleanup.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     path: charts/gcloud-cleanup
     git: git@github.com:travis-ci/kubernetes-config.git
-    ref: master
+    ref: staging
   releaseName: gcloud-cleanup
   values:
     image:
@@ -21,3 +21,5 @@ spec:
       enabled: true
       env: staging-1
       pro: false
+    redis:
+      enabled: true


### PR DESCRIPTION
Currently gcloud-cleanup uses 'Memorystore' from GCP, while this works there are some advantages of running it on GKE:

- Memorystore is 'expensive' and we don't need it to be managed.
- We have spare processing power on GKE, we might as well use it.
- For rate limiting, Redis can run in memory only, we don't need persistence or high availability as the keys are very short lived (seconds to minutes maybe).
- It is a lot closer to the processes, (most of the time) on the same machine less network traffic and lower latency.