### PR TITLE
Add ConfigMap for gcloud-cleanup

### DIFF
--- a/charts/gcloud-cleanup/templates/configmap.yaml
+++ b/charts/gcloud-cleanup/templates/configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gcloud-cleanup.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "gcloud-cleanup.name" . }}
+    helm.sh/chart: {{ include "gcloud-cleanup.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  {{ if .Values.zones -}}
+  GCLOUD_CLEANUP_ZONES: "{{ .Values.zones }}"
+  {{- end }}
+  GCLOUD_CLEANUP_ARCHIVE_SAMPLE_RATE: "10"
+  GCLOUD_CLEANUP_ARCHIVE_SERIAL: "true"
+  GCLOUD_CLEANUP_ENTITIES: instances
+  GCLOUD_CLEANUP_INSTANCE_FILTERS: "name eq ^(testing-gce|travis-job|packer-).*"
+  GCLOUD_CLEANUP_INSTANCE_MAX_AGE: "3h"
+  GCLOUD_CLEANUP_LOOP_SLEEP: "1m"
+  GCLOUD_CLEANUP_OPENCENSUS_SAMPLING_RATE: "10"
+  GCLOUD_CLEANUP_OPENCENSUS_TRACING_ENABLED: "true"
+  GCLOUD_CLEANUP_RATE_LIMIT_PREFIX: gcloud-cleanup
+  GCLOUD_CLEANUP_RATE_LIMIT_DURATION: "2s"
+  GCLOUD_CLEANUP_RATE_LIMIT_MAX_CALLS: "20"

--- a/charts/gcloud-cleanup/templates/deployment.yaml
+++ b/charts/gcloud-cleanup/templates/deployment.yaml
@@ -38,7 +38,16 @@ spec:
                   key: redis-password
             - name: GCLOUD_CLEANUP_RATE_LIMIT_REDIS_URL
               value: redis://:$(GCLOUD_CLEANUP_RATE_LIMIT_REDIS_PASSWORD)@$(GCLOUD_CLEANUP_REDIS_MASTER_SERVICE_HOST):$(GCLOUD_CLEANUP_REDIS_MASTER_SERVICE_PORT)
+          {{- else if .Values.rateLimitRedis.enabled }}
+            - name: GCLOUD_CLEANUP_RATE_LIMIT_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.rateLimitRedis.secretName }}"
+                  key: redis-password
+            - name: GCLOUD_CLEANUP_RATE_LIMIT_REDIS_URL
+              value: redis://:$(GCLOUD_CLEANUP_RATE_LIMIT_REDIS_PASSWORD)@$({{ .Values.rateLimitRedis.envPrefix }}_MASTER_SERVICE_HOST):$({{ .Values.rateLimitRedis.envPrefix }}_MASTER_SERVICE_PORT)
           {{- end }}
+
           envFrom:
             - configMapRef:
                 name: {{ template "gcloud-cleanup.fullname" . }}

--- a/charts/gcloud-cleanup/templates/deployment.yaml
+++ b/charts/gcloud-cleanup/templates/deployment.yaml
@@ -30,10 +30,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 130
           env:
-            {{ range $key, $value := .Values.env }}
-            - name: "{{ $key }}"
-              value: "{{ $value }}"
-            {{ end }}
           {{- if .Values.redis.enabled }}
             - name: GCLOUD_CLEANUP_RATE_LIMIT_REDIS_PASSWORD
               valueFrom:
@@ -44,6 +40,8 @@ spec:
               value: redis://:$(GCLOUD_CLEANUP_RATE_LIMIT_REDIS_PASSWORD)@$(GCLOUD_CLEANUP_REDIS_MASTER_SERVICE_HOST):$(GCLOUD_CLEANUP_REDIS_MASTER_SERVICE_PORT)
           {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ template "gcloud-cleanup.fullname" . }}
             - secretRef:
                 name: {{ template "gcloud-cleanup.secret" . }}
             - secretRef:

--- a/charts/gcloud-cleanup/values.yaml
+++ b/charts/gcloud-cleanup/values.yaml
@@ -24,6 +24,7 @@ trvs:
 secretName: ""
 serviceAccountSecretName: ""
 
+# Self-provisioned Redis through requirements.yaml
 redis:
   enabled: false
   cluster:
@@ -32,5 +33,10 @@ redis:
     persistence:
       enabled: false
 
+# Cluster provided Redis Cluster (see releases/*/rate_limit_redis.yaml)
+rateLimitRedis:
+  enabled: false
+  secretName: rate-limit-redis
+  envPrefix: RATE_LIMIT_REDIS
 
 zones: "us-central1-a,us-central1-b,us-central1-c,us-central1-f"

--- a/charts/gcloud-cleanup/values.yaml
+++ b/charts/gcloud-cleanup/values.yaml
@@ -33,4 +33,4 @@ redis:
       enabled: false
 
 
-env: []
+zones: "us-central1-a,us-central1-b,us-central1-c,us-central1-f"

--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/gcloud-cleanup.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/gcloud-cleanup.yaml
@@ -21,6 +21,8 @@ spec:
       enabled: true
       env: production-1
       pro: false
-    redis:
+    rateLimitRedis:
       enabled: true
+      secretName: rate-limit-redis
+      envPrefix: RATE_LIMIT_REDIS
     replicaCount: 1

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/gcloud-cleanup.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/gcloud-cleanup.yaml
@@ -21,6 +21,8 @@ spec:
       enabled: true
       env: production-2
       pro: false
-    redis:
+    rateLimitRedis:
       enabled: true
+      secretName: rate-limit-redis
+      envPrefix: RATE_LIMIT_REDIS
     replicaCount: 1

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/gcloud-cleanup.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/gcloud-cleanup.yaml
@@ -21,6 +21,8 @@ spec:
       enabled: true
       env: production-3
       pro: false
-    redis:
+    rateLimitRedis:
       enabled: true
+      secretName: rate-limit-redis
+      envPrefix: RATE_LIMIT_REDIS
     replicaCount: 1

--- a/releases/gke_travis-staging-1_us-central1-a_gce-staging-1/gcloud-cleanup.yaml
+++ b/releases/gke_travis-staging-1_us-central1-a_gce-staging-1/gcloud-cleanup.yaml
@@ -21,6 +21,8 @@ spec:
       enabled: true
       env: staging-1
       pro: false
-    redis:
+    rateLimitRedis:
       enabled: true
-    replicaCount: 2
+      secretName: rate-limit-redis
+      envPrefix: RATE_LIMIT_REDIS
+    replicaCount: 1


### PR DESCRIPTION
The defaults included are the current settings on production, I will remove this config from travis-keychain to keep the keychain for secrets only.