### PR TITLE
Increase gce-worker memory request

### DIFF
--- a/charts/gce-worker/templates/cluster.yaml
+++ b/charts/gce-worker/templates/cluster.yaml
@@ -28,7 +28,7 @@ spec:
       resources:
         requests:
           cpu: "100m"
-          memory: 100Mi
+          memory: 500Mi
 
       env:
       - name: POD_NAME

--- a/charts/gce-worker/templates/deployment.yaml
+++ b/charts/gce-worker/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: 100Mi
+            memory: 500Mi
 
         env:
         - name: POD_NAME


### PR DESCRIPTION
There was an increase in 'evicted' workers on the GCE clusters.

Just by looking at `worker-com` workload on a single cluster:
~5G is requested, the request for a single worker is at 100Mi, so this adds up.
~22G memory is used, split evenly among the workers, this comes down to about 500Mi per worker.

The `worker-org` showed less overall 'memory used', but also more 'evicted' workers. Workers on other clusters showed similar numbers.

Conclusion: Increase the requested memory to 500Mi per worker.