### PR TITLE
Move 24 jobs (12/mac env) to .com

### DIFF
--- a/releases/macstadium-prod-1/worker-com.yaml
+++ b/releases/macstadium-prod-1/worker-com.yaml
@@ -14,7 +14,7 @@ spec:
 
     cluster:
       enabled: true
-      maxJobs: 198
+      maxJobs: 210
       maxJobsPerWorker: 30
 
     site: com

--- a/releases/macstadium-prod-1/worker-org.yaml
+++ b/releases/macstadium-prod-1/worker-org.yaml
@@ -14,7 +14,7 @@ spec:
 
     cluster:
       enabled: true
-      maxJobs: 82
+      maxJobs: 70
       maxJobsPerWorker: 20
 
     site: org

--- a/releases/macstadium-prod-2/worker-com.yaml
+++ b/releases/macstadium-prod-2/worker-com.yaml
@@ -14,7 +14,7 @@ spec:
 
     cluster:
       enabled: true
-      maxJobs: 108
+      maxJobs: 120
       maxJobsPerWorker: 30
 
     site: com

--- a/releases/macstadium-prod-2/worker-org.yaml
+++ b/releases/macstadium-prod-2/worker-org.yaml
@@ -14,7 +14,7 @@ spec:
 
     cluster:
       enabled: true
-      maxJobs: 184
+      maxJobs: 172
       maxJobsPerWorker: 30
 
     site: org


### PR DESCRIPTION
As .com has more jobs queued than .org, we are moving more jobs over to .com to balance them out.

prod-1:
.com: 198 -> 210
.org: 82 -> 70

prod-2:
.com: 108 -> 120 
.org: 184 -> 172