### PR TITLE
Create separate workers to test N2 instances efficiency

### DIFF
--- a/charts/gce-worker/templates/configmap.yaml
+++ b/charts/gce-worker/templates/configmap.yaml
@@ -47,6 +47,9 @@ data:
   {{ if .Values.worker_gce_zone -}}
   TRAVIS_WORKER_GCE_ZONE: "{{ .Values.worker_gce_zone }}"
   {{- end }}
+  {{ if .Values.worker_gce_zones -}}
+  TRAVIS_WORKER_GCE_ZONES: "{{ .Values.worker_gce_zones }}"
+  {{- end }}
   TRAVIS_WORKER_GCE_SKIP_STOP_POLL: "true"
   TRAVIS_WORKER_GCE_UPLOAD_RETRIES: "300"
   {{ if .Values.project -}}

--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-n2-com.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-n2-com.yaml
@@ -1,0 +1,39 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: worker-n2-com
+  namespace: gce-production-1
+spec:
+  chart:
+    path: charts/gce-worker
+    git: git@github.com:travis-ci/kubernetes-config.git
+    ref: master
+  releaseName: worker-n2-com
+  values:
+    image:
+      repository: travisci/worker
+      tag: v6.2.5-7-g941b20c
+
+    cluster:
+      enabled: true
+      maxJobs: 100
+      maxJobsPerWorker: 50
+
+    site: com
+    queue: builds.gce-n2
+    project: eco-emissary-99515
+    librato_source_prefix: production-1-gce
+
+    trvs:
+      enabled: true
+      app: gce-workers
+      env: production-1
+      pro: true
+
+    rateLimitRedis:
+      enabled: true
+      secretName: rate-limit-redis
+      envPrefix: RATE_LIMIT_REDIS
+
+    default_machine_type: "n2-standard-2"
+    worker_gce_zones: "us-central1-c,us-central1-f"


### PR DESCRIPTION
Related PR to route `travis-ci` jobs to new queue https://github.com/travis-pro/travis-pro-keychain/pull/410