### PR TITLE
Skip helm init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ addons:
   - name: helm
     classic: true
 
-before_script:
-- helm init --client-only
-
 before_deploy:
 - ls dist
 - openssl aes-256-cbc -K $encrypted_8a2a23268e29_key -iv $encrypted_8a2a23268e29_iv

--- a/k8s/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/ns.yaml
+++ b/k8s/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/ns.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: gce-production-1-ue1
-  name: gce-production-1-ue1
+    name: gce-production-1
+  name: gce-production-1
 ---

--- a/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-premium-c2.yaml
+++ b/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-premium-c2.yaml
@@ -2,7 +2,7 @@ apiVersion: flux.weave.works/v1beta1
 kind: HelmRelease
 metadata:
   name: worker-premium-c2
-  namespace: gce-production-1-ue1
+  namespace: gce-production-1
 spec:
   chart:
     path: charts/gce-worker
@@ -16,11 +16,11 @@ spec:
 
     cluster:
       enabled: true
-      maxJobs: 350
+      maxJobs: 10
       maxJobsPerWorker: 50
 
     site: com
-    queue: builds.gce-premium-c2
+    queue: builds.us-east1-test
     project: eco-emissary-99515
     librato_source_prefix: production-1-gce
 


### PR DESCRIPTION
Builds in this repo are failing with error:
```
0.84s$ helm init --client-only

Error: unknown flag: --client-only
```

According to helm documentation running helm init is not needed anymore:

> The helm init command has been removed. It performed two primary functions. First, it installed Tiller. This is no longer needed. Second, it setup directories and repositories where Helm configuration lived. This is now automated. If the directory is not present it will be created.