### PR TITLE
Disable us-central1-f zone for n2 machines and adjust maxjobs

### DIFF
--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-com.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-com.yaml
@@ -16,7 +16,7 @@ spec:
 
     cluster:
       enabled: true
-      maxJobs: 2500
+      maxJobs: 750
       maxJobsPerWorker: 50
 
     site: com
@@ -36,4 +36,4 @@ spec:
       envPrefix: RATE_LIMIT_REDIS
 
     default_machine_type: "n2-standard-2"
-    worker_gce_zones: "us-central1-c,us-central1-f"
+    worker_gce_zones: "us-central1-c"

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-org.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-org.yaml
@@ -16,7 +16,7 @@ spec:
 
     cluster:
       enabled: true
-      maxJobs: 2000
+      maxJobs: 750
       maxJobsPerWorker: 50
 
     site: org
@@ -36,5 +36,5 @@ spec:
       envPrefix: RATE_LIMIT_REDIS
 
     default_machine_type: "n2-standard-2"
-    worker_gce_zones: "us-central1-c,us-central1-f"
+    worker_gce_zones: "us-central1-c"
     


### PR DESCRIPTION
https://travisci.assembla.com/spaces/Operations/tickets/104-switch-default_machine_type-to-n2-standard-2/details#