### PR TITLE
Migrate kubernetes-config repository to travis-infrastructure

### DIFF
--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/gcloud-cleanup.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/gcloud-cleanup.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   chart:
     path: charts/gcloud-cleanup
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: gcloud-cleanup
   values:

--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-com-free.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-com-free.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-com-free
   values:

--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-com.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-com
   values:

--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-n2-com.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-n2-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-n2-com
   values:

--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-org.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-org
   values:

--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-premium-c2.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-premium-c2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-c2
   values:

--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-premium-hack.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-premium-hack.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-hack
   values:

--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-premium-n2.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-premium-n2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-n2
   values:

--- a/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/gcloud-cleanup.yaml
+++ b/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/gcloud-cleanup.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   chart:
     path: charts/gcloud-cleanup
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: gcloud-cleanup
   values:

--- a/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-com.yaml
+++ b/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-com
   values:

--- a/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-org.yaml
+++ b/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-org
   values:

--- a/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-premium-c2.yaml
+++ b/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-premium-c2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-c2
   values:

--- a/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-premium-n2.yaml
+++ b/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-premium-n2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-n2
   values:

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/gcloud-cleanup.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/gcloud-cleanup.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   chart:
     path: charts/gcloud-cleanup
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: gcloud-cleanup
   values:

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-com-free.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-com-free.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-com-free
   values:

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-com.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-com
   values:

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-org.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-org
   values:

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-premium-c2.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-premium-c2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-c2
   values:

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-premium-hack.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-premium-hack.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-hack
   values:

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-premium-n2-highcpu.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-premium-n2-highcpu.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-n2-highcpu
   values:

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-premium-n2-highmem.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-premium-n2-highmem.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-n2-highmem
   values:

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-premium-n2.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-premium-n2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-n2
   values:

--- a/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/gcloud-cleanup.yaml
+++ b/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/gcloud-cleanup.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   chart:
     path: charts/gcloud-cleanup
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: gcloud-cleanup
   values:

--- a/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-com.yaml
+++ b/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-com
   values:

--- a/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-org.yaml
+++ b/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-org
   values:

--- a/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-premium-c2.yaml
+++ b/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-premium-c2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-c2
   values:

--- a/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-premium-n2.yaml
+++ b/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-premium-n2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-n2
   values:

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/gcloud-cleanup.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/gcloud-cleanup.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   chart:
     path: charts/gcloud-cleanup
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: gcloud-cleanup
   values:

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-com-free.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-com-free.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-com-free
   values:

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-com.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-com
   values:

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-org.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-org
   values:

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-premium-c2.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-premium-c2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-c2
   values:

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-premium-hack.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-premium-hack.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-hack
   values:

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-premium-n2-highcpu.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-premium-n2-highcpu.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-n2-highcpu
   values:

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-premium-n2-highmem.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-premium-n2-highmem.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-n2-highmem
   values:

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-premium-n2.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-premium-n2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-n2
   values:

--- a/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-com.yaml
+++ b/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-com
   values:

--- a/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-org.yaml
+++ b/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-org
   values:

--- a/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-premium-c2.yaml
+++ b/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-premium-c2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-c2
   values:

--- a/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-premium-n2.yaml
+++ b/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-premium-n2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: master
   releaseName: worker-premium-n2
   values:

--- a/releases/macstadium-prod-1/collectd-vsphere.yaml
+++ b/releases/macstadium-prod-1/collectd-vsphere.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/collectd-vsphere
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: collectd-vsphere
   values:
     trvs:

--- a/releases/macstadium-prod-1/jupiter-brain-com.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-com
   values:
     image:

--- a/releases/macstadium-prod-1/jupiter-brain-custom-1.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-custom-1.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-custom-1
   values:
     trvs:

--- a/releases/macstadium-prod-1/jupiter-brain-custom-2.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-custom-2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-custom-2
   values:
     trvs:

--- a/releases/macstadium-prod-1/jupiter-brain-custom-4.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-custom-4.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-custom-4
   values:
     trvs:

--- a/releases/macstadium-prod-1/jupiter-brain-custom-5.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-custom-5.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-custom-5
   values:
     trvs:

--- a/releases/macstadium-prod-1/jupiter-brain-custom-6.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-custom-6.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-custom-6
   values:
     trvs:

--- a/releases/macstadium-prod-1/jupiter-brain-custom-7.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-custom-7.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-custom-7
   values:
     trvs:

--- a/releases/macstadium-prod-1/jupiter-brain-org.yaml
+++ b/releases/macstadium-prod-1/jupiter-brain-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-org
   values:
     image:

--- a/releases/macstadium-prod-1/macbot.yaml
+++ b/releases/macstadium-prod-1/macbot.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   chart:
     path: charts/macbot
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: macbot
   values:
     macbot:

--- a/releases/macstadium-prod-1/statsd.yaml
+++ b/releases/macstadium-prod-1/statsd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/statsd
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: statsd
   values:
     secretEnv: macstadium_prod_1

--- a/releases/macstadium-prod-1/vsphere-janitor-custom-1.yaml
+++ b/releases/macstadium-prod-1/vsphere-janitor-custom-1.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-janitor-custom-1
   values:
     trvs:

--- a/releases/macstadium-prod-1/vsphere-janitor-custom-2.yaml
+++ b/releases/macstadium-prod-1/vsphere-janitor-custom-2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-janitor-custom-2
   values:
     trvs:

--- a/releases/macstadium-prod-1/vsphere-janitor-custom-4.yaml
+++ b/releases/macstadium-prod-1/vsphere-janitor-custom-4.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-janitor-custom-4
   values:
     trvs:

--- a/releases/macstadium-prod-1/vsphere-janitor-custom-5.yaml
+++ b/releases/macstadium-prod-1/vsphere-janitor-custom-5.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-janitor-custom-5
   values:
     trvs:

--- a/releases/macstadium-prod-1/vsphere-janitor-custom-6.yaml
+++ b/releases/macstadium-prod-1/vsphere-janitor-custom-6.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-janitor-custom-6
   values:
     trvs:

--- a/releases/macstadium-prod-1/vsphere-janitor.yaml
+++ b/releases/macstadium-prod-1/vsphere-janitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-janitor
   values:
     trvs:

--- a/releases/macstadium-prod-1/vsphere-monitor.yaml
+++ b/releases/macstadium-prod-1/vsphere-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-monitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-monitor
   values:
     trvs:

--- a/releases/macstadium-prod-1/worker-com.yaml
+++ b/releases/macstadium-prod-1/worker-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-com
   values:
     image:

--- a/releases/macstadium-prod-1/worker-custom-1.yaml
+++ b/releases/macstadium-prod-1/worker-custom-1.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-custom-1
   values:
     image:

--- a/releases/macstadium-prod-1/worker-custom-2.yaml
+++ b/releases/macstadium-prod-1/worker-custom-2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-custom-2
   values:
     image:

--- a/releases/macstadium-prod-1/worker-custom-4.yaml
+++ b/releases/macstadium-prod-1/worker-custom-4.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-custom-4
   values:
     image:

--- a/releases/macstadium-prod-1/worker-custom-5.yaml
+++ b/releases/macstadium-prod-1/worker-custom-5.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-custom-5
   values:
     image:

--- a/releases/macstadium-prod-1/worker-custom-7.yaml
+++ b/releases/macstadium-prod-1/worker-custom-7.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-custom-7
   values:
     image:

--- a/releases/macstadium-prod-1/worker-org.yaml
+++ b/releases/macstadium-prod-1/worker-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-org
   values:
     image:

--- a/releases/macstadium-prod-2/collectd-vsphere.yaml
+++ b/releases/macstadium-prod-2/collectd-vsphere.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/collectd-vsphere
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: collectd-vsphere
   values:
     trvs:

--- a/releases/macstadium-prod-2/jupiter-brain-com.yaml
+++ b/releases/macstadium-prod-2/jupiter-brain-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-com
   values:
     image:

--- a/releases/macstadium-prod-2/jupiter-brain-custom-1.yaml
+++ b/releases/macstadium-prod-2/jupiter-brain-custom-1.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-custom-1
   values:
     trvs:

--- a/releases/macstadium-prod-2/jupiter-brain-custom-2.yaml
+++ b/releases/macstadium-prod-2/jupiter-brain-custom-2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-custom-2
   values:
     trvs:

--- a/releases/macstadium-prod-2/jupiter-brain-custom-4.yaml
+++ b/releases/macstadium-prod-2/jupiter-brain-custom-4.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-custom-4
   values:
     trvs:

--- a/releases/macstadium-prod-2/jupiter-brain-custom-5.yaml
+++ b/releases/macstadium-prod-2/jupiter-brain-custom-5.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-custom-5
   values:
     trvs:

--- a/releases/macstadium-prod-2/jupiter-brain-org.yaml
+++ b/releases/macstadium-prod-2/jupiter-brain-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: jupiter-brain-org
   values:
     image:

--- a/releases/macstadium-prod-2/statsd.yaml
+++ b/releases/macstadium-prod-2/statsd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/statsd
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: statsd
   values:
     secretEnv: macstadium_prod_2

--- a/releases/macstadium-prod-2/vsphere-janitor-custom-1.yaml
+++ b/releases/macstadium-prod-2/vsphere-janitor-custom-1.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-janitor-custom-1
   values:
     trvs:

--- a/releases/macstadium-prod-2/vsphere-janitor-custom-2.yaml
+++ b/releases/macstadium-prod-2/vsphere-janitor-custom-2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-janitor-custom-2
   values:
     trvs:

--- a/releases/macstadium-prod-2/vsphere-janitor-custom-4.yaml
+++ b/releases/macstadium-prod-2/vsphere-janitor-custom-4.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-janitor-custom-4
   values:
     trvs:

--- a/releases/macstadium-prod-2/vsphere-janitor-custom-5.yaml
+++ b/releases/macstadium-prod-2/vsphere-janitor-custom-5.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-janitor-custom-5
   values:
     trvs:

--- a/releases/macstadium-prod-2/vsphere-janitor.yaml
+++ b/releases/macstadium-prod-2/vsphere-janitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-janitor
   values:
     trvs:

--- a/releases/macstadium-prod-2/vsphere-monitor.yaml
+++ b/releases/macstadium-prod-2/vsphere-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-monitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: vsphere-monitor
   values:
     trvs:

--- a/releases/macstadium-prod-2/worker-com.yaml
+++ b/releases/macstadium-prod-2/worker-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-com
   values:
     image:

--- a/releases/macstadium-prod-2/worker-custom-1.yaml
+++ b/releases/macstadium-prod-2/worker-custom-1.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-custom-1
   values:
     image:

--- a/releases/macstadium-prod-2/worker-custom-2.yaml
+++ b/releases/macstadium-prod-2/worker-custom-2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-custom-2
   values:
     image:

--- a/releases/macstadium-prod-2/worker-custom-4.yaml
+++ b/releases/macstadium-prod-2/worker-custom-4.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-custom-4
   values:
     image:

--- a/releases/macstadium-prod-2/worker-custom-5.yaml
+++ b/releases/macstadium-prod-2/worker-custom-5.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-custom-5
   values:
     image:

--- a/releases/macstadium-prod-2/worker-org.yaml
+++ b/releases/macstadium-prod-2/worker-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
   releaseName: worker-org
   values:
     image:

--- a/shared/install-flux.sh
+++ b/shared/install-flux.sh
@@ -13,7 +13,7 @@ helm upgrade flux fluxcd/flux \
   --set rbac.create=true \
   --set helmOperator.create=true \
   --set helmOperator.createCRD=true \
-  --set git.url=git@github.com:travis-ci/kubernetes-config.git \
+  --set git.url=git@github.com:travis-infrastructure/kubernetes-config.git \
   --set git.branch="$BRANCH" \
   --set "git.path=releases/$NAMESPACE" \
   --set git.pollInterval=1m \

--- a/shared/update-staging.sh
+++ b/shared/update-staging.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GIT_URL="https://$GITHUB_TOKEN@github.com/travis-ci/kubernetes-config.git"
+GIT_URL="https://$GITHUB_TOKEN@github.com/travis-infrastructure/kubernetes-config.git"
 
 merge_to_staging() {
   git fetch origin staging:staging
@@ -21,7 +21,7 @@ merge_pr_to_staging() {
 }
 
 if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-  if [[ "$TRAVIS_PULL_REQUEST_SLUG" == "travis-ci/kubernetes-config" ]]; then
+  if [[ "$TRAVIS_PULL_REQUEST_SLUG" == "travis-infrastructure/kubernetes-config" ]]; then
     merge_pr_to_staging
   fi
 elif [[ "$TRAVIS_BRANCH" == "master" ]]; then


### PR DESCRIPTION
Due to migration of services to k8s, we are planning to move this repository to the travis-infrastructure org and make it private.