### PR TITLE
Migrate kubernetes-config repository to travis-infrastructure (staging)

### DIFF
--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/fluxbot.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/fluxbot.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chart:
     path: charts/fluxbot
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: fluxbot
   values:

--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/node-red.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/node-red.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   chart:
     path: charts/node-red
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: node-red
   values:

--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/shield-com.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/shield-com.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chart:
     path: charts/shield
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: shield-com
   values:

--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/shield-org.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/shield-org.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chart:
     path: charts/shield
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: shield-org
   values:

--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-autoscaler.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-autoscaler.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   chart:
     path: charts/travis-autoscaler
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: travis-autoscaler
   values:

--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-build-org.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-build-org.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chart:
     path: charts/travis-build
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: travis-build
   values:

--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-listener-pro.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-listener-pro.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chart:
     path: charts/travis-listener
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: travis-listener-pro
   values:

--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-listener.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-listener.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chart:
     path: charts/travis-listener
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: travis-listener
   values:

--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-scheduler-pro.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-scheduler-pro.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chart:
     path: charts/travis-scheduler
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: travis-scheduler
   values:

--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-scheduler.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-scheduler.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chart:
     path: charts/travis-scheduler
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: travis-scheduler
   values:

--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-vcs-pro.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-vcs-pro.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   chart:
     path: charts/travis-vcs
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: travis-vcs-pro
   values:

--- a/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-vcs.yaml
+++ b/releases/gke_travis-ci-staging-services-1_us-central1_travis-ci-services/travis-vcs.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   chart:
     path: charts/travis-vcs
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: travis-vcs
   values:

--- a/releases/gke_travis-staging-1_us-central1_workers-1/gcloud-cleanup.yaml
+++ b/releases/gke_travis-staging-1_us-central1_workers-1/gcloud-cleanup.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   chart:
     path: charts/gcloud-cleanup
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: gcloud-cleanup
   values:

--- a/releases/gke_travis-staging-1_us-central1_workers-1/worker-com-free.yaml
+++ b/releases/gke_travis-staging-1_us-central1_workers-1/worker-com-free.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: worker-com-free
   values:

--- a/releases/gke_travis-staging-1_us-central1_workers-1/worker-com.yaml
+++ b/releases/gke_travis-staging-1_us-central1_workers-1/worker-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: worker-com
   values:

--- a/releases/gke_travis-staging-1_us-central1_workers-1/worker-org-k8s-queue.yaml
+++ b/releases/gke_travis-staging-1_us-central1_workers-1/worker-org-k8s-queue.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: worker-org-k8s-queue
   values:

--- a/releases/gke_travis-staging-1_us-central1_workers-1/worker-org-test-ue1.yaml
+++ b/releases/gke_travis-staging-1_us-central1_workers-1/worker-org-test-ue1.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: worker-org-test-ue1
   values:

--- a/releases/gke_travis-staging-1_us-central1_workers-1/worker-org.yaml
+++ b/releases/gke_travis-staging-1_us-central1_workers-1/worker-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/gce-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: worker-org
   values:

--- a/releases/macstadium-staging/collectd-vsphere.yaml
+++ b/releases/macstadium-staging/collectd-vsphere.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/collectd-vsphere
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: collectd-vsphere
   values:

--- a/releases/macstadium-staging/jupiter-brain-com.yaml
+++ b/releases/macstadium-staging/jupiter-brain-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: jupiter-brain-com
   values:

--- a/releases/macstadium-staging/jupiter-brain-org.yaml
+++ b/releases/macstadium-staging/jupiter-brain-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/jupiter-brain
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: jupiter-brain-org
   values:

--- a/releases/macstadium-staging/statsd.yaml
+++ b/releases/macstadium-staging/statsd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/statsd
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: statsd
   values:

--- a/releases/macstadium-staging/vsphere-janitor.yaml
+++ b/releases/macstadium-staging/vsphere-janitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-janitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: vsphere-janitor
   values:

--- a/releases/macstadium-staging/vsphere-monitor.yaml
+++ b/releases/macstadium-staging/vsphere-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/vsphere-monitor
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: vsphere-monitor
   values:

--- a/releases/macstadium-staging/worker-com.yaml
+++ b/releases/macstadium-staging/worker-com.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: worker-com
   values:

--- a/releases/macstadium-staging/worker-org.yaml
+++ b/releases/macstadium-staging/worker-org.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     path: charts/macstadium-worker
-    git: git@github.com:travis-ci/kubernetes-config.git
+    git: git@github.com:travis-infrastructure/kubernetes-config.git
     ref: staging
   releaseName: worker-org
   values:

--- a/shared/install-flux.sh
+++ b/shared/install-flux.sh
@@ -13,7 +13,7 @@ helm upgrade flux fluxcd/flux \
   --set rbac.create=true \
   --set helmOperator.create=true \
   --set helmOperator.createCRD=true \
-  --set git.url=git@github.com:travis-ci/kubernetes-config.git \
+  --set git.url=git@github.com:travis-infrastructure/kubernetes-config.git \
   --set git.branch="$BRANCH" \
   --set "git.path=releases/$NAMESPACE" \
   --set git.pollInterval=1m \

--- a/shared/update-staging.sh
+++ b/shared/update-staging.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GIT_URL="https://$GITHUB_TOKEN@github.com/travis-ci/kubernetes-config.git"
+GIT_URL="https://$GITHUB_TOKEN@github.com/travis-infrastructure/kubernetes-config.git"
 
 merge_to_staging() {
   git fetch origin staging:staging
@@ -21,7 +21,7 @@ merge_pr_to_staging() {
 }
 
 if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-  if [[ "$TRAVIS_PULL_REQUEST_SLUG" == "travis-ci/kubernetes-config" ]]; then
+  if [[ "$TRAVIS_PULL_REQUEST_SLUG" == "travis-infrastructure/kubernetes-config" ]]; then
     merge_pr_to_staging
   fi
 elif [[ "$TRAVIS_BRANCH" == "master" ]]; then


### PR DESCRIPTION
Due to migration of services to k8s, we are planning to move this repository to the travis-infrastructure org and make it private.