### PR TITLE
Bump up images to current deployed version and adjust maxjobs

### DIFF
--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-com.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-com.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 400
+      maxJobs: 300
       maxJobsPerWorker: 50
 
     site: com

--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-n2-com.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-n2-com.yaml
@@ -12,7 +12,7 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.5-7-g941b20c
+      tag: v6.2.8
 
     cluster:
       enabled: true

--- a/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-org.yaml
+++ b/releases/gke_eco-emissary-99515_us-central1_gce-production-1/worker-org.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 400
+      maxJobs: 300
       maxJobsPerWorker: 50
 
     site: org

--- a/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-com.yaml
+++ b/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-com.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 750
+      maxJobs: 900
       maxJobsPerWorker: 50
 
     site: com

--- a/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-org.yaml
+++ b/releases/gke_eco-emissary-99515_us-east1_gce-production-1-ue1/worker-org.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 750
+      maxJobs: 900
       maxJobsPerWorker: 50
 
     site: org

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-com.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-com.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 400
+      maxJobs: 300
       maxJobsPerWorker: 50
 
     site: com

--- a/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-org.yaml
+++ b/releases/gke_travis-ci-prod-2_us-central1_gce-production-2/worker-org.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 400
+      maxJobs: 200
       maxJobsPerWorker: 50
 
     site: org

--- a/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-com.yaml
+++ b/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-com.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 750
+      maxJobs: 900
       maxJobsPerWorker: 50
 
     site: com

--- a/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-org.yaml
+++ b/releases/gke_travis-ci-prod-2_us-east1_gce-production-2-ue1/worker-org.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 750
+      maxJobs: 900
       maxJobsPerWorker: 50
 
     site: org

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-com.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-com.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 400
+      maxJobs: 300
       maxJobsPerWorker: 50
 
     site: com

--- a/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-org.yaml
+++ b/releases/gke_travis-ci-prod-3_us-central1_gce-production-3/worker-org.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 400
+      maxJobs: 300
       maxJobsPerWorker: 50
 
     site: org

--- a/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-com.yaml
+++ b/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-com.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 750
+      maxJobs: 900
       maxJobsPerWorker: 50
 
     site: com

--- a/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-org.yaml
+++ b/releases/gke_travis-ci-prod-3_us-east1_gce-production-3-ue1/worker-org.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     image:
       repository: travisci/worker
-      tag: v6.2.6
+      tag: v6.2.8
 
     cluster:
       enabled: true
-      maxJobs: 750
+      maxJobs: 900
       maxJobsPerWorker: 50
 
     site: org


### PR DESCRIPTION
This has to be merged before moving repo to travis-infrastructure
@cesar-cs please look if this is reflecting current state of workers after recent upgrade?